### PR TITLE
Remove unused formatted logging methods

### DIFF
--- a/pkg/ifaces/logger/nop_logger.go
+++ b/pkg/ifaces/logger/nop_logger.go
@@ -10,18 +10,6 @@ type NopLogger struct{}
 // zh: Debug 級別，不輸出內容。
 func (NopLogger) Debug(msg string, args ...any) {}
 
-// Infof does nothing.
-// zh: Info 級別，不輸出內容。
-func (NopLogger) Infof(format string, args ...any) {}
-
-// Warnf does nothing.
-// zh: Warn 級別，不輸出內容。
-func (NopLogger) Warnf(format string, args ...any) {}
-
-// Errorf does nothing.
-// zh: Error 級別，不輸出內容。
-func (NopLogger) Errorf(format string, args ...any) {}
-
 // Sync does nothing and returns nil.
 // zh: 不需 flush，直接回傳 nil。
 func (NopLogger) Sync() error { return nil }


### PR DESCRIPTION
## Summary
- prune formatted logging methods in `NopLogger`

## Testing
- `go test ./...` *(fails: unable to download Go 1.24.3 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68466e3dee64832d9a50bad3c32eaa82