### PR TITLE
Fix metric query interface name

### DIFF
--- a/internal/adapters/alert/evaluator.go
+++ b/internal/adapters/alert/evaluator.go
@@ -32,7 +32,7 @@ func (e *DefaultAlertEvaluator) Evaluate(ctx context.Context, cond alert.AlertCo
 	e.Log.Debug("evaluating alert condition", "expr", cond.Expr, "threshold", cond.Threshold)
 
 	// 查詢指標資料
-	value, err := e.Query.QueryValue(ctx, cond.Expr, cond.Labels)
+	value, err := e.Query.Query(ctx, cond.Expr, cond.Labels)
 	if err != nil {
 		e.Log.Error("query failed", "error", err)
 		return alert.AlertResult{

--- a/pkg/ifaces/metric/query.go
+++ b/pkg/ifaces/metric/query.go
@@ -7,5 +7,5 @@ import "context"
 type MetricQueryAdapter interface {
 	// Query executes a query expression with optional label filters and returns a numeric result.
 	// zh: 執行查詢語句並搭配可選的標籤篩選，回傳單一數值結果。
-	QueryValue(ctx context.Context, expr string, labels map[string]string) (float64, error)
+	Query(ctx context.Context, expr string, labels map[string]string) (float64, error)
 }


### PR DESCRIPTION
## Summary
- rename `MetricQueryAdapter.QueryValue` method to `Query`
- update alert evaluator to use renamed method

## Testing
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68466e02cfac832d94b577dcc5aece2c