### PR TITLE
Remove duplicate alert handler registration

### DIFF
--- a/internal/plugins/eventbus/alertlog/alert_handler.go
+++ b/internal/plugins/eventbus/alertlog/alert_handler.go
@@ -28,9 +28,3 @@ func (h *AlertPluginHandler) HandleAlertTriggered(ctx context.Context, e event.A
 	}).Info("[ALERT] triggered")
 	return nil
 }
-
-// Register this plugin handler during package initialization.
-// zh: 套件初始化時將此 plugin handler 註冊至事件總線。
-func init() {
-	eventbus.RegisterAlertHandler(&AlertPluginHandler{})
-}


### PR DESCRIPTION
## Summary
- clean up duplicate plugin registration in alert_handler.go

## Testing
- `go test ./internal/plugins/eventbus/alertlog ./internal/test/plugins/eventbus/alertlog` *(fails: go: download go1.24.3: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68466e3c4d38832daf50784064a8fa52