### PR TITLE
Add adapter tests and test fakes

### DIFF
--- a/internal/adapters/eventbus/alert_test.go
+++ b/internal/adapters/eventbus/alert_test.go
@@ -1,0 +1,46 @@
+package eventbusadapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/detectviz/detectviz/internal/test/fakes"
+	"github.com/detectviz/detectviz/pkg/ifaces/event"
+	ifacelogger "github.com/detectviz/detectviz/pkg/ifaces/logger"
+)
+
+func TestAlertLoggerHandler_HandleAlertTriggered(t *testing.T) {
+	l := &fakes.FakeLogger{}
+	ctx := ifacelogger.WithContext(context.Background(), l)
+	h := &AlertLoggerHandler{}
+	err := h.HandleAlertTriggered(ctx, event.AlertTriggeredEvent{
+		AlertID:    "a",
+		RuleName:   "rule",
+		Level:      "critical",
+		Instance:   "inst",
+		Metric:     "m",
+		Comparison: "<",
+		Value:      1,
+		Threshold:  2,
+		Message:    "msg",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(l.Entries))
+	}
+	if l.Entries[0].Level != "INFO" {
+		t.Errorf("expected INFO level, got %s", l.Entries[0].Level)
+	}
+}
+
+func TestAlertHandlerRegistry(t *testing.T) {
+	alertHandlers = nil
+	h := &AlertLoggerHandler{}
+	RegisterAlertHandler(h)
+	list := LoadPluginAlertHandlers()
+	if len(list) != 1 || list[0] != h {
+		t.Fatalf("handler registry not working: %#v", list)
+	}
+}

--- a/internal/adapters/eventbus/host_test.go
+++ b/internal/adapters/eventbus/host_test.go
@@ -1,0 +1,40 @@
+package eventbusadapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/detectviz/detectviz/internal/test/fakes"
+	"github.com/detectviz/detectviz/pkg/ifaces/event"
+	ifacelogger "github.com/detectviz/detectviz/pkg/ifaces/logger"
+)
+
+func TestHostLoggerHandler_HandleHostDiscovered(t *testing.T) {
+	l := &fakes.FakeLogger{}
+	ctx := ifacelogger.WithContext(context.Background(), l)
+	h := &HostLoggerHandler{}
+	err := h.HandleHostDiscovered(ctx, event.HostDiscoveredEvent{
+		Name:   "host1",
+		Source: "scanner",
+		Labels: map[string]string{"env": "dev"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(l.Entries))
+	}
+	if l.Entries[0].Level != "INFO" {
+		t.Errorf("expected INFO level, got %s", l.Entries[0].Level)
+	}
+}
+
+func TestHostHandlerRegistry(t *testing.T) {
+	hostHandlers = nil
+	h := &HostLoggerHandler{}
+	RegisterHostHandler(h)
+	list := LoadPluginHostHandlers()
+	if len(list) != 1 || list[0] != h {
+		t.Fatalf("handler registry not working: %#v", list)
+	}
+}

--- a/internal/adapters/eventbus/metric_test.go
+++ b/internal/adapters/eventbus/metric_test.go
@@ -1,0 +1,42 @@
+package eventbusadapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/detectviz/detectviz/internal/test/fakes"
+	"github.com/detectviz/detectviz/pkg/ifaces/event"
+	ifacelogger "github.com/detectviz/detectviz/pkg/ifaces/logger"
+)
+
+func TestMetricLoggerHandler_HandleMetricOverflow(t *testing.T) {
+	l := &fakes.FakeLogger{}
+	ctx := ifacelogger.WithContext(context.Background(), l)
+	h := &MetricLoggerHandler{}
+	err := h.HandleMetricOverflow(ctx, event.MetricOverflowEvent{
+		MetricName: "cpu",
+		Value:      95,
+		Threshold:  90,
+		Instance:   "host1",
+		Reason:     "high",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(l.Entries))
+	}
+	if l.Entries[0].Level != "WARN" {
+		t.Errorf("expected WARN level, got %s", l.Entries[0].Level)
+	}
+}
+
+func TestMetricHandlerRegistry(t *testing.T) {
+	metricHandlers = nil
+	h := &MetricLoggerHandler{}
+	RegisterMetricHandler(h)
+	list := LoadPluginMetricHandlers()
+	if len(list) != 1 || list[0] != h {
+		t.Fatalf("handler registry not working: %#v", list)
+	}
+}

--- a/internal/adapters/eventbus/task_test.go
+++ b/internal/adapters/eventbus/task_test.go
@@ -1,0 +1,40 @@
+package eventbusadapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/detectviz/detectviz/internal/test/fakes"
+	"github.com/detectviz/detectviz/pkg/ifaces/event"
+	ifacelogger "github.com/detectviz/detectviz/pkg/ifaces/logger"
+)
+
+func TestTaskLoggerHandler_HandleTaskCompleted(t *testing.T) {
+	l := &fakes.FakeLogger{}
+	ctx := ifacelogger.WithContext(context.Background(), l)
+	h := &TaskLoggerHandler{}
+	err := h.HandleTaskCompleted(ctx, event.TaskCompletedEvent{
+		TaskID:   "id",
+		WorkerID: "worker",
+		Status:   "done",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(l.Entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(l.Entries))
+	}
+	if l.Entries[0].Level != "INFO" {
+		t.Errorf("expected INFO level, got %s", l.Entries[0].Level)
+	}
+}
+
+func TestTaskHandlerRegistry(t *testing.T) {
+	taskHandlers = nil
+	h := &TaskLoggerHandler{}
+	RegisterTaskHandler(h)
+	list := LoadPluginTaskHandlers()
+	if len(list) != 1 || list[0] != h {
+		t.Fatalf("handler registry not working: %#v", list)
+	}
+}

--- a/internal/adapters/logger/logger_test.go
+++ b/internal/adapters/logger/logger_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestZapLogger_Info(t *testing.T) {
 	core, observedLogs := observer.New(zapcore.InfoLevel)
-	baseLogger := zap.New(core) // 正確建立 zap.Logger
+	baseLogger := zap.New(core) // zh: 正確建立 zap.Logger
 	sugar := baseLogger.Sugar()
 
 	zapLogger := loggeradapter.NewZapLogger(sugar)
@@ -47,5 +47,24 @@ func TestNopLogger_NoPanic(t *testing.T) {
 
 	if log2 == nil {
 		t.Error("NopLogger should return non-nil instance")
+	}
+}
+
+func TestZapLogger_WithFieldsAndNamed(t *testing.T) {
+	core, observedLogs := observer.New(zapcore.InfoLevel)
+	base := zap.New(core).Sugar()
+	log := loggeradapter.NewZapLogger(base)
+	child := log.Named("child").WithFields(map[string]any{"k": "v"})
+	child.Info("msg")
+	entries := observedLogs.All()
+	if len(entries) == 0 {
+		t.Fatal("no log entry recorded")
+	}
+	entry := entries[len(entries)-1]
+	if entry.Message != "msg" {
+		t.Errorf("unexpected message: %s", entry.Message)
+	}
+	if entry.LoggerName != "child" {
+		t.Errorf("expected logger name child, got %s", entry.LoggerName)
 	}
 }

--- a/internal/adapters/notifier/email_adapter_test.go
+++ b/internal/adapters/notifier/email_adapter_test.go
@@ -1,0 +1,35 @@
+package notifieradapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/detectviz/detectviz/internal/test/fakes"
+	notifieriface "github.com/detectviz/detectviz/pkg/ifaces/notifier"
+)
+
+func TestEmailNotifier_Send(t *testing.T) {
+	log := &fakes.FakeLogger{}
+	n := NewEmailNotifier("email", "noreply@example.com", log)
+	err := n.Send(context.Background(), notifieriface.Message{Target: "to@example.com", Title: "hi", Content: "msg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(log.Entries) == 0 {
+		t.Error("expected log entry recorded")
+	}
+	if n.Name() != "email" {
+		t.Errorf("unexpected Name: %s", n.Name())
+	}
+}
+
+func TestEmailNotifier_Notify(t *testing.T) {
+	log := &fakes.FakeLogger{}
+	n := NewEmailNotifier("email", "noreply@example.com", log)
+	if err := n.Notify("title", "content"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(log.Entries) == 0 {
+		t.Error("expected log entry recorded")
+	}
+}

--- a/internal/adapters/notifier/slack_adapter_test.go
+++ b/internal/adapters/notifier/slack_adapter_test.go
@@ -1,0 +1,35 @@
+package notifieradapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/detectviz/detectviz/internal/test/fakes"
+	notifieriface "github.com/detectviz/detectviz/pkg/ifaces/notifier"
+)
+
+func TestSlackNotifier_Send(t *testing.T) {
+	log := &fakes.FakeLogger{}
+	n := NewSlackNotifier("slack", "https://example.com", log)
+	err := n.Send(context.Background(), notifieriface.Message{Target: "https://hooks.slack", Title: "hi", Content: "msg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(log.Entries) == 0 {
+		t.Error("expected log entry recorded")
+	}
+	if n.Name() != "slack" {
+		t.Errorf("unexpected Name: %s", n.Name())
+	}
+}
+
+func TestSlackNotifier_Notify(t *testing.T) {
+	log := &fakes.FakeLogger{}
+	n := NewSlackNotifier("slack", "https://example.com", log)
+	if err := n.Notify("title", "content"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(log.Entries) == 0 {
+		t.Error("expected log entry recorded")
+	}
+}

--- a/internal/adapters/notifier/webhook_adapter_test.go
+++ b/internal/adapters/notifier/webhook_adapter_test.go
@@ -1,0 +1,53 @@
+package notifieradapter
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/detectviz/detectviz/internal/test/fakes"
+	notifieriface "github.com/detectviz/detectviz/pkg/ifaces/notifier"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestWebhookNotifier_Send(t *testing.T) {
+	log := &fakes.FakeLogger{}
+	var capturedURL string
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedURL = req.URL.String()
+		return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(nil))}, nil
+	})}
+	n := NewWebhookNotifier("hook", log, client)
+	msg := notifieriface.Message{Target: "http://example.com", Title: "hi", Content: "msg"}
+	err := n.Send(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedURL != "http://example.com" {
+		t.Errorf("unexpected URL: %s", capturedURL)
+	}
+	if len(log.Entries) == 0 {
+		t.Error("expected log entry recorded")
+	}
+}
+
+func TestWebhookNotifier_Notify(t *testing.T) {
+	log := &fakes.FakeLogger{}
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewBuffer(nil))}, nil
+	})}
+	n := NewWebhookNotifier("hook", log, client)
+	if err := n.Notify("title", "content"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(log.Entries) == 0 {
+		t.Error("expected log entry recorded")
+	}
+}

--- a/internal/test/fakes/fake_eventbus.go
+++ b/internal/test/fakes/fake_eventbus.go
@@ -1,0 +1,83 @@
+package fakes
+
+import (
+	"context"
+
+	"github.com/detectviz/detectviz/pkg/ifaces/event"
+	"github.com/detectviz/detectviz/pkg/ifaces/eventbus"
+)
+
+// FakeEventBus implements eventbus.EventDispatcher for tests.
+// zh: 測試用 EventDispatcher 假實作，紀錄事件與 handler 呼叫狀態。
+type FakeEventBus struct {
+	AlertEvents  []event.AlertTriggeredEvent
+	TaskEvents   []event.TaskCompletedEvent
+	HostEvents   []event.HostDiscoveredEvent
+	MetricEvents []event.MetricOverflowEvent
+
+	AlertHandlers  []eventbus.AlertEventHandler
+	TaskHandlers   []eventbus.TaskEventHandler
+	HostHandlers   []eventbus.HostEventHandler
+	MetricHandlers []eventbus.MetricEventHandler
+
+	DispatchAlertErr  error
+	DispatchTaskErr   error
+	DispatchHostErr   error
+	DispatchMetricErr error
+}
+
+func (b *FakeEventBus) DispatchAlertTriggered(ctx context.Context, e event.AlertTriggeredEvent) error {
+	b.AlertEvents = append(b.AlertEvents, e)
+	for _, h := range b.AlertHandlers {
+		if err := h.HandleAlertTriggered(ctx, e); err != nil {
+			return err
+		}
+	}
+	return b.DispatchAlertErr
+}
+
+func (b *FakeEventBus) RegisterAlertHandler(h eventbus.AlertEventHandler) {
+	b.AlertHandlers = append(b.AlertHandlers, h)
+}
+
+func (b *FakeEventBus) DispatchTaskCompleted(ctx context.Context, e event.TaskCompletedEvent) error {
+	b.TaskEvents = append(b.TaskEvents, e)
+	for _, h := range b.TaskHandlers {
+		if err := h.HandleTaskCompleted(ctx, e); err != nil {
+			return err
+		}
+	}
+	return b.DispatchTaskErr
+}
+
+func (b *FakeEventBus) RegisterTaskHandler(h eventbus.TaskEventHandler) {
+	b.TaskHandlers = append(b.TaskHandlers, h)
+}
+
+func (b *FakeEventBus) DispatchHostDiscovered(ctx context.Context, e event.HostDiscoveredEvent) error {
+	b.HostEvents = append(b.HostEvents, e)
+	for _, h := range b.HostHandlers {
+		if err := h.HandleHostDiscovered(ctx, e); err != nil {
+			return err
+		}
+	}
+	return b.DispatchHostErr
+}
+
+func (b *FakeEventBus) RegisterHostHandler(h eventbus.HostEventHandler) {
+	b.HostHandlers = append(b.HostHandlers, h)
+}
+
+func (b *FakeEventBus) DispatchMetricOverflow(ctx context.Context, e event.MetricOverflowEvent) error {
+	b.MetricEvents = append(b.MetricEvents, e)
+	for _, h := range b.MetricHandlers {
+		if err := h.HandleMetricOverflow(ctx, e); err != nil {
+			return err
+		}
+	}
+	return b.DispatchMetricErr
+}
+
+func (b *FakeEventBus) RegisterMetricHandler(h eventbus.MetricEventHandler) {
+	b.MetricHandlers = append(b.MetricHandlers, h)
+}

--- a/internal/test/fakes/fake_logger.go
+++ b/internal/test/fakes/fake_logger.go
@@ -1,0 +1,39 @@
+package fakes
+
+import (
+	"context"
+	"sync"
+
+	ifacelogger "github.com/detectviz/detectviz/pkg/ifaces/logger"
+)
+
+// LogEntry records a logging call for verification in tests.
+// zh: 用於測試中紀錄 logger 輸出內容。
+type LogEntry struct {
+	Level string
+	Msg   string
+	Args  []any
+}
+
+// FakeLogger implements logger.Logger and stores log entries.
+// zh: 簡易的 logger 假實作，會收集所有輸出訊息供檢查。
+type FakeLogger struct {
+	mu      sync.Mutex
+	Entries []LogEntry
+}
+
+func (l *FakeLogger) record(level, msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.Entries = append(l.Entries, LogEntry{Level: level, Msg: msg, Args: args})
+}
+
+func (l *FakeLogger) Debug(msg string, args ...any) { l.record("DEBUG", msg, args...) }
+func (l *FakeLogger) Info(msg string, args ...any)  { l.record("INFO", msg, args...) }
+func (l *FakeLogger) Warn(msg string, args ...any)  { l.record("WARN", msg, args...) }
+func (l *FakeLogger) Error(msg string, args ...any) { l.record("ERROR", msg, args...) }
+
+func (l *FakeLogger) Named(name string) ifacelogger.Logger                { return l }
+func (l *FakeLogger) WithContext(ctx context.Context) ifacelogger.Logger  { return l }
+func (l *FakeLogger) WithFields(fields map[string]any) ifacelogger.Logger { return l }
+func (l *FakeLogger) Sync() error                                         { return nil }

--- a/internal/test/fakes/fake_notifier.go
+++ b/internal/test/fakes/fake_notifier.go
@@ -1,0 +1,39 @@
+package fakes
+
+import (
+	"context"
+
+	notifieriface "github.com/detectviz/detectviz/pkg/ifaces/notifier"
+)
+
+// FakeNotifier is a simple notifier implementation used for tests.
+// zh: 測試用 Notifier 假實作，用於驗證通知流程。
+type FakeNotifier struct {
+	NameVal     string
+	NotifyCalls []NotifyCall
+	SendCalls   []SendCall
+	NotifyErr   error
+	SendErr     error
+}
+
+type NotifyCall struct {
+	Title   string
+	Message string
+}
+
+type SendCall struct {
+	Ctx context.Context
+	Msg notifieriface.Message
+}
+
+func (f *FakeNotifier) Name() string { return f.NameVal }
+
+func (f *FakeNotifier) Notify(title, message string) error {
+	f.NotifyCalls = append(f.NotifyCalls, NotifyCall{Title: title, Message: message})
+	return f.NotifyErr
+}
+
+func (f *FakeNotifier) Send(ctx context.Context, msg notifieriface.Message) error {
+	f.SendCalls = append(f.SendCalls, SendCall{Ctx: ctx, Msg: msg})
+	return f.SendErr
+}


### PR DESCRIPTION
## Summary
- add fakes for logger, notifier and eventbus for testing
- cover eventbus handlers with unit tests
- cover notifier adapters with unit tests
- extend zap logger tests
- fix Chinese comment style

## Testing
- `golangci-lint run ./...` *(fails: undefined symbols in integration tests)*
- `go test ./...` *(fails: could not connect to redis and other integration resources)*

------
https://chatgpt.com/codex/tasks/task_e_6847c37f462c832d9af48d93d713721f